### PR TITLE
chore: update to bl 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const BufferList = require('bl')
+const { BufferList } = require('bl')
 
 module.exports = source => {
   const reader = (async function * () {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { BufferList } = require('bl')
+const BufferList = require('bl/BufferList')
 
 module.exports = source => {
   const reader = (async function * () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -672,11 +672,11 @@
       "dev": true
     },
     "bl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
-      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.0.tgz",
+      "integrity": "sha512-QwQvAZZA1Bw1FWnhNj2X5lu+sPxxB2ITH3mqEqYyahN6JZR13ONjk+XiTnBaGEzMPUrAgOkaD68pBH1rvPRPsw==",
       "requires": {
-        "readable-stream": "^3.0.1"
+        "readable-stream": "^3.4.0"
       }
     },
     "bluebird": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "compileEnhancements": false
   },
   "dependencies": {
-    "bl": "^3.0.0"
+    "bl": "^4.0.0"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 const Crypto = require('crypto')
-const BufferList = require('bl')
+const { BufferList } = require('bl')
 const Reader = require('.')
 
 test('should read from source with too big first chunk', async t => {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 const Crypto = require('crypto')
-const { BufferList } = require('bl')
+const BufferList = require('bl/BufferList')
 const Reader = require('.')
 
 test('should read from source with too big first chunk', async t => {


### PR DESCRIPTION
This updates to `bl` 4. The export was changed to `{ BufferList }` because the default export is a BL backed by readable-stream, which shouldn't be needed.

`bl` 4 fixes an issue where different versions of the module would cause BufferLists to be converted into empty Buffers. This will ensure better stability in larger systems where multiple versions of `bl` might be installed.