### PR TITLE
fix: allow passing undefined to reader next method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Uint8ArrayList } from 'uint8arraylist'
 import type { Source } from 'it-stream-types'
 
 export interface Reader extends AsyncGenerator<Uint8ArrayList, void, any> {
-  next: (...args: [] | [number]) => Promise<IteratorResult<Uint8ArrayList, void>>
+  next: (...args: [] | [number | undefined]) => Promise<IteratorResult<Uint8ArrayList, void>>
 }
 
 export function reader (source: Source<Uint8Array>) {


### PR DESCRIPTION
The `bytes` value is optional and null-guarded so we can accept undefined as a value.