### PR TITLE
fix: accept uint8arraylists as input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export interface Reader extends AsyncGenerator<Uint8ArrayList, void, any> {
   next: (...args: [] | [number | undefined]) => Promise<IteratorResult<Uint8ArrayList, void>>
 }
 
-export function reader (source: Source<Uint8Array>) {
+export function reader (source: Source<Uint8Array | Uint8ArrayList>) {
   const reader: Reader = (async function * (): AsyncGenerator<Uint8ArrayList, void, any> {
     // @ts-expect-error first yield in stream is ignored
     let bytes: number | undefined = yield // Allows us to receive 8 when reader.next(8) is called


### PR DESCRIPTION
Expand input type to allow no-copy usage