### PR TITLE
fix!: Uint8Arrays are generic

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,14 +151,10 @@
   },
   "dependencies": {
     "it-stream-types": "^2.0.1",
-    "uint8arraylist": "^2.0.0"
+    "uint8arraylist": "^3.0.1"
   },
   "devDependencies": {
     "aegir": "^48.0.1",
     "iso-random-stream": "^2.0.2"
-  },
-  "engines": {
-    "node": ">=16.0.0",
-    "npm": ">=7.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import type { Source } from 'it-stream-types'
  * A specialized `AsyncGenerator` that lets you pass a number to the `.next` method which
  * will attempt to return only that many bytes.
  */
-export interface Reader<T extends ArrayBufferLike> extends AsyncGenerator<Uint8ArrayList<T>, void, any> {
+export interface Reader<T extends ArrayBufferLike = ArrayBufferLike> extends AsyncGenerator<Uint8ArrayList<T>, void, any> {
   next(...args: [] | [number | undefined]): Promise<IteratorResult<Uint8ArrayList<T>, void>>
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ import type { Source } from 'it-stream-types'
  * A specialized `AsyncGenerator` that lets you pass a number to the `.next` method which
  * will attempt to return only that many bytes.
  */
-export interface Reader extends AsyncGenerator<Uint8ArrayList, void, any> {
-  next(...args: [] | [number | undefined]): Promise<IteratorResult<Uint8ArrayList, void>>
+export interface Reader<T extends ArrayBufferLike> extends AsyncGenerator<Uint8ArrayList<T>, void, any> {
+  next(...args: [] | [number | undefined]): Promise<IteratorResult<Uint8ArrayList<T>, void>>
 }
 
 /**
@@ -31,17 +31,17 @@ export interface Reader extends AsyncGenerator<Uint8ArrayList, void, any> {
  * }
  * ```
  */
-export function reader (source: Source<Uint8Array | Uint8ArrayList>): Reader {
-  const reader: Reader = (async function * (): AsyncGenerator<Uint8ArrayList, void, any> {
+export function reader <T extends ArrayBufferLike> (source: Source<Uint8Array<T> | Uint8ArrayList<T>>): Reader<T> {
+  const reader: Reader<T> = (async function * (): AsyncGenerator<Uint8ArrayList<T>, void, any> {
     // @ts-expect-error first yield in stream is ignored
     let bytes: number | undefined = yield // Allows us to receive 8 when reader.next(8) is called
-    let bl = new Uint8ArrayList()
+    let bl = new Uint8ArrayList<T>()
 
     for await (const chunk of source) {
       if (bytes == null) {
         bl.append(chunk)
         bytes = yield bl
-        bl = new Uint8ArrayList()
+        bl = new Uint8ArrayList<T>()
         continue
       }
 


### PR DESCRIPTION
Since https://github.com/microsoft/TypeScript/pull/59417 `Uint8Array`s backed by `ArrayBuffer` are incompatible with those backed with `SharedArrayBuffer` so be explicit about the types returned.

BREAKING CHANGE: the returned `Uint8ArrayList` have a generic type that reflects the internal buffer type